### PR TITLE
feat: 🎸 对有网址的链接提供“访问网站”入口

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,8 +209,13 @@ def render(data_path: str):
                 if 'type' in v:
                     one_click = f'''
     + [一键导入](legado://import/{v['type']}?src={url})'''
+                website_link = ''
+                if 'website' in item:
+                    website_link = f'''
+    + [访问网站]({item['website']})'''
                 content += f'''
 * {title}
+    {website_link}
     + [访问直链]({url}){one_click}
     + 上一次同步状态: {item['status']}
     + 更新时间: {item['modify_time']}

--- a/source/book.json
+++ b/source/book.json
@@ -5,6 +5,7 @@
     {
       "title": "XIU2精品书源",
       "url": "https://github.com/XIU2/Yuedu/raw/master/shuyuan",
+      "website": "https://github.com/XIU2/Yuedu",
       "tag": [
         "\uD83D\uDD25"
       ]
@@ -12,6 +13,7 @@
     {
       "title": "一程的书源合集",
       "url": "https://www.gitlink.org.cn/api/yi-c/yd/raw/sy.json?ref=master",
+      "website": "https://www.gitlink.org.cn/yi-c/yd",
       "tag": [
         "\uD83D\uDD25"
       ]
@@ -19,6 +21,7 @@
     {
       "title": "破冰书源",
       "url": "https://github.com/PB-pobing/pobing/raw/pb/sy.json?ref=master",
+      "website": "https://github.com/PB-pobing/pobing",
       "tag": [
         "\uD83D\uDD25"
       ]
@@ -47,6 +50,7 @@
     {
       "title": "风停在了窗边",
       "url": "https://www.gitlink.org.cn/api/fcdlcb/ydsy/raw/bookSource.json?ref=master",
+      "website": "https://www.gitlink.org.cn/fcdlcb/ydsy",
       "tag": []
     },
     {


### PR DESCRIPTION
- 配置项的每个“item”如果有website属性，则为其渲染一个“访问网站”入口

> 很多订阅链接没找到官网或仓库地址
> 不确定一些简单的配置（比如配色方案）要不要提供一个本地文件路径