### PR TITLE
ci: 添加 Gitea镜像同步

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,3 +82,10 @@ jobs:
           sudo git commit -m "Add sync changes"
           sudo git show-ref --verify --quiet refs/heads/release || sudo git checkout -b release
           sudo git push -f origin release
+          
+      - name: Repo Mirror Sync
+        uses: kubeservice-stack/repos-mirror-action@v1.0.5
+        with:
+          target-url: https://gitea.com/aoaostar/legado.git
+          target-username: aoaostar
+          target-token: ${{ secrets.GITEA_ACCESS_TOKEN }}


### PR DESCRIPTION
- 在 GitHub Actions 中添加 Repo Mirror Sync 步骤
- 使用 kubeservice-stack/repos-mirror-action 实现镜像同步
- 目标 URL 为 https://gitea.com/aoaostar/legado.git- 通过 secrets.GITEA_ACCESS_TOKEN 进行身份验证