### PR TITLE
build: 更新 repo_url 为 Gitea 地址 (#22)

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -1,3 +1,3 @@
 max_concurrent = 10
 
-repo_url = "https://ghgo.xyz/https://github.com/aoaostar/legado/raw/release"
+repo_url = "https://gitea.com/aoaostar/legado/raw/branch/release"


### PR DESCRIPTION
- 将 repo_url 从 GitHub 地址改为 Gitea 地址
- 新地址为 https://gitea.com/aoaostar/legado/raw/branch/release