### PR TITLE
refactor(settings): 更新资源库 URL 地址 (#25)

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -1,3 +1,3 @@
 max_concurrent = 10
 
-repo_url = "https://gitea.com/aoaostar/legado/raw/branch/release"
+repo_url = "https://legado.aoaostar.com"


### PR DESCRIPTION
- 将 repo_url 从 Gitea 地址更改为自定义域名
- 新 URL: https://legado.aoaostar.com